### PR TITLE
gcc13.x fix

### DIFF
--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.h
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.h
@@ -10,7 +10,9 @@
  */
 
 #pragma once
-
+#include <cstdint>
+#include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <vector>
 #include "rasterizer.h"

--- a/submodules/diff-gaussian-rasterization/setup.py
+++ b/submodules/diff-gaussian-rasterization/setup.py
@@ -27,7 +27,15 @@ setup(
             "cuda_rasterizer/adam.cu",
             "rasterize_points.cu",
             "ext.cpp"],
-            extra_compile_args={"nvcc": ["-I" + os.path.join(os.path.dirname(os.path.abspath(__file__)), "third_party/glm/")]})
+            extra_compile_args={
+                "cxx": ["-O3", "-std=c++17"],
+                "nvcc": [
+                    "-O3",
+                    "--use_fast_math",
+                    "-std=c++17",
+                    "-D__STDC_FORMAT_MACROS",
+                    "-I" + os.path.join(os.path.dirname(os.path.abspath(__file__)), "third_party/glm/")
+                ]}
         ],
     cmdclass={
         'build_ext': BuildExtension

--- a/submodules/diff-gaussian-rasterization/setup.py
+++ b/submodules/diff-gaussian-rasterization/setup.py
@@ -35,8 +35,8 @@ setup(
                     "-std=c++17",
                     "-D__STDC_FORMAT_MACROS",
                     "-I" + os.path.join(os.path.dirname(os.path.abspath(__file__)), "third_party/glm/")
-                ]}
-        ],
+                    ]}
+                )],
     cmdclass={
         'build_ext': BuildExtension
     }


### PR DESCRIPTION
added includes required for gcc13 compilation, and extra compile args to 
compiled on conda environments with gcc 13.4  and cuda 12.8,  and  gcc 12.4 and cuda 12.6.


